### PR TITLE
feat(preview): add /api/preview/disable endpoint

### DIFF
--- a/app/api/preview/disable/route.ts
+++ b/app/api/preview/disable/route.ts
@@ -1,0 +1,11 @@
+import { draftMode } from 'next/headers'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const slug = searchParams.get('slug') || 'home'
+  // Disable draft mode for this browser session
+  draftMode().disable()
+  return Response.redirect(new URL(`/${slug}`, req.url))
+}
+
+

--- a/scripts/seed-downtown-and-fragment.js
+++ b/scripts/seed-downtown-and-fragment.js
@@ -4,6 +4,7 @@
 // Usage: node -r dotenv/config scripts/seed-downtown-and-fragment.js dotenv_config_path=.env.local
 
 const { createClient } = require('@sanity/client')
+const crypto = require('crypto')
 
 const PROJECT_ID = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
 const DATASET = process.env.NEXT_PUBLIC_SANITY_DATASET || 'production'
@@ -15,7 +16,11 @@ if (!PROJECT_ID || !TOKEN) {
 }
 
 const client = createClient({ projectId: PROJECT_ID, dataset: DATASET, token: TOKEN, apiVersion: '2023-05-03', useCdn: false })
-const pt = (text) => ([{ _type: 'block', style: 'normal', children: [{ _type: 'span', text }] }])
+const pt = (text) => {
+  const key = (crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2))
+  const childKey = (crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2))
+  return [{ _key: key, _type: 'block', style: 'normal', children: [{ _key: childKey, _type: 'span', text }] }]
+}
 
 async function upsertFragment() {
   const fragId = 'fragment.trust'
@@ -24,7 +29,7 @@ async function upsertFragment() {
     _type: 'fragment',
     title: 'Trust + Why Book Direct',
     sections: [
-      { _type: 'richText', body: pt('Why Book Direct? — Transparent pricing, flexible cancellation, loyalty benefits, and 0% commission.') },
+      { _key: crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2), _type: 'richText', body: pt('Why Book Direct? — Transparent pricing, flexible cancellation, loyalty benefits, and 0% commission.') },
     ],
   }
   await client.createOrReplace(frag)
@@ -39,9 +44,9 @@ async function upsertDowntownPage() {
     title: 'Downtown Toronto Hotels',
     slug: { _type: 'slug', current: 'hotels/toronto-downtown' },
     sections: [
-      { _type: 'hero', headline: 'Downtown Toronto Hotels', subhead: 'Handpicked stays in the core—book direct with the hotel.' },
-      { _type: 'richText', body: pt('Browse popular downtown hotels and points of interest. Prices shown are direct from hotels.') },
-      { _type: 'hotelCarousel', title: 'Downtown picks', hotels: [] },
+      { _key: crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2), _type: 'hero', headline: 'Downtown Toronto Hotels', subhead: 'Handpicked stays in the core—book direct with the hotel.' },
+      { _key: crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2), _type: 'richText', body: pt('Browse popular downtown hotels and points of interest. Prices shown are direct from hotels.') },
+      { _key: crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2), _type: 'hotelCarousel', title: 'Downtown picks', hotels: [] },
     ],
   }
   await client.createOrReplace(doc)

--- a/scripts/sync-static-pages.js
+++ b/scripts/sync-static-pages.js
@@ -4,6 +4,7 @@
 // Usage: node -r dotenv/config scripts/sync-static-pages.js dotenv_config_path=.env.local
 
 const { createClient } = require('@sanity/client')
+const crypto = require('crypto')
 
 const PROJECT_ID = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
 const DATASET = process.env.NEXT_PUBLIC_SANITY_DATASET || 'production'
@@ -19,12 +20,17 @@ if (!TOKEN) {
 }
 
 const client = createClient({ projectId: PROJECT_ID, dataset: DATASET, token: TOKEN, apiVersion: '2023-05-03', useCdn: false })
-const pt = (text) => ([{ _type: 'block', style: 'normal', children: [{ _type: 'span', text }] }])
+const pt = (text) => {
+  const key = (crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2))
+  const childKey = (crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2))
+  return [{ _key: key, _type: 'block', style: 'normal', children: [{ _key: childKey, _type: 'span', text }] }]
+}
 
 async function upsertBySlug(slug, title, sections) {
   const existing = await client.fetch(`*[_type=="page" && slug.current==$slug][0]{_id}`, { slug })
   const _id = existing?._id || `page.${slug.replace(/\//g,'-')}`
-  return client.createOrReplace({ _id, _type: 'page', title, slug: { _type: 'slug', current: slug }, sections })
+  const withKeys = (arr=[]) => arr.map((it)=> ({ _key: it._key || (crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)), ...it }))
+  return client.createOrReplace({ _id, _type: 'page', title, slug: { _type: 'slug', current: slug }, sections: withKeys(sections) })
 }
 
 async function run() {


### PR DESCRIPTION
Adds GET /api/preview/disable to turn off draftMode and redirect back to a slug.
This fixes the inability to exit preview on production.
