### PR TITLE
feat(revalidate): revalidate concrete page paths derived from tags

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -10,13 +10,28 @@ export async function POST(req: Request) {
     const paths: string[] = Array.isArray(body?.paths) ? body.paths : []
     const tags: string[] = Array.isArray(body?.tags) ? body.tags : []
 
+    // Derive page paths from tags like "page:about" so even if tag cache misses,
+    // we also revalidate the concrete route path.
+    const derivedPathsFromTags = Array.from(
+      new Set(
+        (tags || [])
+          .filter((t) => typeof t === 'string' && t.startsWith('page:'))
+          .map((t) => {
+            const slug = t.slice('page:'.length)
+            if (!slug) return '/'
+            return slug === 'home' ? '/' : `/${slug}`
+          })
+      )
+    )
+
     if (tags.length > 0) {
       for (const t of tags) revalidateTag(t)
     }
-    if (paths.length > 0) {
-      for (const p of paths) revalidatePath(p)
+    const allPaths = [...new Set([...(paths || []), ...derivedPathsFromTags])]
+    if (allPaths.length > 0) {
+      for (const p of allPaths) revalidatePath(p)
     }
-    return Response.json({ revalidated: { paths, tags } })
+    return Response.json({ revalidated: { paths: allPaths, tags } })
   } catch {
     return Response.json({ revalidated: false }, { status: 400 })
   }


### PR DESCRIPTION
When webhook posts {"tags":["page:about", ...]}, also revalidate the concrete route paths (/, /about, etc.) in addition to revalidateTag(). This ensures updates go live even if tag cache didnt hit.
