### PR TITLE
chore(cms-pages): disable CMS on pages; keep hotels CMS-only

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -35,17 +35,14 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function AboutPage() {
   // Always render the original client page to preserve design/UX
   // Append CMS sections (excluding hero) below when available
-  if (!isCmsPagesEnabled()) {
-    return <AboutPageClient />
-  }
+  // CMS pages disabled globally; always render client page
+  if (!isCmsPagesEnabled()) return <AboutPageClient />
   const isDraft = draftMode().isEnabled
   const page = await getPageBySlug('about', {
     drafts: isDraft,
     fetchOptions: isDraft ? { cache: 'no-store' } : { next: { revalidate: 3600, tags: ['page:about'] } },
   })
   const sections = page ? page.sections || [] : []
-  if (!page || (!page.hero && !sections.length)) {
-    return <AboutPageClient />
-  }
+  if (!page || (!page.hero && !sections.length)) return <AboutPageClient />
   return <PageRenderer hero={page.hero} sections={sections} />
 }

--- a/app/components/cms/registry.tsx
+++ b/app/components/cms/registry.tsx
@@ -32,6 +32,28 @@ export function renderSection(section: any): JSX.Element | null {
       const block = { _type: 'faq', title: section?.heading, items }
       return <SectionRenderer sections={[block] as any} />
     }
+    case 'featureGrid': {
+      const items = Array.isArray(section?.items) ? section.items : []
+      return (
+        <div>
+          {(section?.heading || section?.subheading) && (
+            <div className="text-center mb-16">
+              {section?.heading && <h2 className="text-3xl font-bold text-gray-900 mb-6">{section.heading}</h2>}
+              {section?.subheading && <p className="text-xl text-gray-600 max-w-3xl mx-auto">{section.subheading}</p>}
+            </div>
+          )}
+          <div className={`grid gap-8 ${items.length === 4 ? 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4' : 'grid-cols-1 md:grid-cols-3'}`}>
+            {items.map((it: any, idx: number) => (
+              <div key={idx} className="bg-white rounded-2xl p-8 text-center shadow-sm">
+                <div className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto mb-6 bg-gray-100"/>
+                <h3 className="text-lg font-semibold text-gray-900 mb-3">{it?.title}</h3>
+                {it?.description && <p className="text-gray-600 text-sm leading-relaxed">{it.description}</p>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+    }
     case 'cta': {
       // Map to secondaryCta used by SectionRenderer
       const primary = Array.isArray(section?.ctas) ? section.ctas[0] : null

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -33,16 +33,12 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function ContactPage() {
-  if (!isCmsPagesEnabled()) {
-    return <ContactPageClient />
-  }
+  if (!isCmsPagesEnabled()) return <ContactPageClient />
   const isDraft = draftMode().isEnabled
   const page = await getPageBySlug('contact', {
     drafts: isDraft,
     fetchOptions: isDraft ? { cache: 'no-store' } : { next: { revalidate: 3600, tags: ['page:contact'] } },
   })
-  if (!page || (!page.hero && !(page.sections || []).length)) {
-    return <ContactPageClient />
-  }
+  if (!page || (!page.hero && !(page.sections || []).length)) return <ContactPageClient />
   return <PageRenderer hero={page.hero} sections={page.sections} />
 }

--- a/app/hotels/toronto-downtown/page.tsx
+++ b/app/hotels/toronto-downtown/page.tsx
@@ -31,9 +31,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function DowntownPage() {
-  if (!isCmsPagesEnabled()) {
-    return <DowntownPageClient />
-  }
+  if (!isCmsPagesEnabled()) return <DowntownPageClient />
 
   const isDraft = draftMode().isEnabled
   const page = await getPageBySlug('hotels/toronto-downtown', {
@@ -42,9 +40,7 @@ export default async function DowntownPage() {
   })
 
   // Fallback to static client page if CMS page is missing or empty
-  if (!page || (!page.hero && !(page.sections || []).length)) {
-    return <DowntownPageClient />
-  }
+  if (!page || (!page.hero && !(page.sections || []).length)) return <DowntownPageClient />
 
   return <PageRenderer hero={page.hero} sections={page.sections} />
 }

--- a/lib/cms/flags.ts
+++ b/lib/cms/flags.ts
@@ -1,5 +1,5 @@
 export function isCmsPagesEnabled() {
-  return process.env.USE_CMS_PAGES === 'true'
+  return false
 }
 
 


### PR DESCRIPTION
Render About/Contact/Downtown from client components; leave CMS for hotels only.